### PR TITLE
Default value for invalid input

### DIFF
--- a/custom_components/unraid/sensor.py
+++ b/custom_components/unraid/sensor.py
@@ -29,6 +29,9 @@ _LOGGER = logging.getLogger(__name__)
 
 def format_size(size_in_bytes: float) -> str:
     """Format size to appropriate unit."""
+    if size_in_bytes is None or not isinstance(size_in_bytes, (int, float)):
+        return "0 B"  # Default value for invalid input
+        
     units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB']
     size = float(size_in_bytes)
     unit_index = 0

--- a/custom_components/unraid/sensor.py
+++ b/custom_components/unraid/sensor.py
@@ -744,18 +744,21 @@ class UnraidMotherboardTemperatureSensor(UnraidSensorBase):
             temp_data = self.coordinator.data["system_stats"].get("temperature_data", {})
             sensors_data = temp_data.get("sensors", {})
 
-            # Common motherboard temperature patterns
+            # Common motherboard temperature patterns in priority order
             mb_patterns = [
                 'mb temp', 'board temp', 'system temp',
                 'motherboard', 'systin', 'temp1'
             ]
 
-            for sensor_data in sensors_data.values():
-                for key, value in sensor_data.items():
-                    if isinstance(value, (str, float)):
-                        if any(pattern in key.lower() for pattern in mb_patterns):
-                            if temp := self._parse_temperature(str(value)):
-                                return temp
+            # Iterate through each pattern in the specified order
+            for pattern in mb_patterns:
+                pattern_lower = pattern.lower()
+	            for sensor_data in sensors_data.values():
+	                for key, value in sensor_data.items():
+                        if isinstance(value, (str, float)) and pattern_lower in key.lower():
+                            temp = self._parse_temperature(str(value))
+                            if temp is not None:
+	                                return temp
 
             return None
 


### PR DESCRIPTION
When Unraid Cache does not exist, the error happens and sensors are only updated once on integration load and do not get refreshed.
This change adds default behaviour or returning 0 B when empty object is passed.

`
[31m2024-11-21 14:54:54.859 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved (None)
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 266, in _handle_refresh_interval
    await self._async_refresh(log_failures=True, scheduled=True)
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 481, in _async_refresh
    self.async_update_listeners()
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 176, in async_update_listeners
    update_callback()
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 561, in _handle_coordinator_update
    self.async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1007, in async_write_ha_state
    self._async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1132, in _async_write_ha_state
    self.__async_calculate_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1073, in __async_calculate_state
    if extra_state_attributes := self.extra_state_attributes:
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/unraid/sensor.py", line 353, in extra_state_attributes
    "total_size": format_size(cache_usage.get("total", 0)),
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/unraid/sensor.py", line 33, in format_size
    size = float(size_in_bytes)
           ^^^^^^^^^^^^^^^^^^^^
TypeError: float() argument must be a string or a real number, not 'NoneType'[0m
`